### PR TITLE
Fix ESP32 compatibility issues

### DIFF
--- a/examples/Example1-DMXOutput/Example1-DMXOutput.ino
+++ b/examples/Example1-DMXOutput/Example1-DMXOutput.ino
@@ -26,12 +26,6 @@ SparkFunDMX dmx;
 #define PAN_CHANNEL 4
 #define TILT_CHANNEL 5
 
-//Pin Definitions for ESP32 WROOM DMX to LED Shield
-#define CLOCK = 5;
-#define DATA0 = 19;
-#define DATA1 = 18;
-#define DATA2 = 27;
-
 uint8_t x = 0;
 
 void setup() {

--- a/examples/Example2-DMXInput/Example2-DMXInput.ino
+++ b/examples/Example2-DMXInput/Example2-DMXInput.ino
@@ -19,11 +19,23 @@
 
 SparkFunDMX dmx;
 
-//Pin Definitions for ESP32 WROOM
-#define CLOCK 5
-#define DATA0 19
-#define DATA1 18
-#define DATA2 27
+//Pin Definitions for ESP32 Thing Plus boards
+#if defined(ARDUINO_ESP32_THING_PLUS)
+#define CLOCK = 5;
+#define DATA0 = 19;
+#define DATA1 = 18;
+#define DATA2 = 27;
+#elif defined(ARDUINO_ESP32_THING_PLUS_C)
+#define CLOCK = 18;
+#define DATA0 = 19;
+#define DATA1 = 23;
+#define DATA2 = 33;
+#elif defined(ARDUINO_ESP32S2_THING_PLUS)
+#define CLOCK = 36;
+#define DATA0 = 37;
+#define DATA1 = 35;
+#define DATA2 = 11;
+#endif
 
 //Channel Defintions
 #define TOTAL_CHANNELS 5

--- a/examples/Example3-MovingHead/Example3-MovingHead.ino
+++ b/examples/Example3-MovingHead/Example3-MovingHead.ino
@@ -32,11 +32,23 @@ const int endUniverse = 0;//end Universe should be total channels/512
 bool sendFrame = 1;
 int previousDataLength = 0;
 
-//Pin Definitions for ESP32 WROOM
-#define CLOCK 5
-#define DATA0 19
-#define DATA1 18
-#define DATA2 27
+//Pin Definitions for ESP32 Thing Plus boards
+#if defined(ARDUINO_ESP32_THING_PLUS)
+#define CLOCK = 5;
+#define DATA0 = 19;
+#define DATA1 = 18;
+#define DATA2 = 27;
+#elif defined(ARDUINO_ESP32_THING_PLUS_C)
+#define CLOCK = 18;
+#define DATA0 = 19;
+#define DATA1 = 23;
+#define DATA2 = 33;
+#elif defined(ARDUINO_ESP32S2_THING_PLUS)
+#define CLOCK = 36;
+#define DATA0 = 37;
+#define DATA1 = 35;
+#define DATA2 = 11;
+#endif
 
 //Channel and Peripheral Definitions
 #define NUM_LEDS 64

--- a/library.properties
+++ b/library.properties
@@ -1,9 +1,9 @@
 name=SparkFun DMX Shield Library
-version=1.0.5
+version=1.1.0
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the SparkFun ESP32 DMX to LED Shield
 paragraph=An Arduino Library for the ESP32 DMX to LED Shield. Accomplishes DMX communication over Serial
 category=Sensors
 url=https://github.com/sparkfun/SparkFunDMX
-architectures=*
+architectures=esp32

--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -154,6 +154,11 @@ void SparkFunDMX::update() {
   { 
 	if (_startCodeDetected == true)
 	{
+    // If there are extra bytes in serial buffer, remove them
+    while(DMXSerial.available() > chanSize)
+    {
+      DMXSerial.read();
+    }
 		while (DMXSerial.available())
 		{
 			dmxData[currentChannel++] = DMXSerial.read();

--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -13,6 +13,13 @@ or concerns with licensing, please contact techsupport@sparkfun.com.
 Distributed as-is; no warranty is given.
 ******************************************************************************/
 
+// Verify this is a valid platform (SparkFun ESP32 Thing Plus boards only)
+#if !(defined(ARDUINO_ESP32_THING_PLUS) \
+  || defined(ARDUINO_ESP32_THING_PLUS_C) \
+  || defined(ARDUINO_ESP32S2_THING_PLUS))
+#error SparkFun DMX library can only be used with ESP32 Thing Plus boards!
+#endif
+
 /* ----- LIBRARIES ----- */
 #include <Arduino.h>
 
@@ -25,9 +32,19 @@ Distributed as-is; no warranty is given.
 #define DMXSPEED       250000
 #define DMXFORMAT      SERIAL_8N2
 
-int enablePin = 21;		//dafault on ESP32
+#if defined(ARDUINO_ESP32_THING_PLUS)
+int enablePin = 21;
 int rxPin = 16;
 int txPin = 17;
+#elif defined(ARDUINO_ESP32_THING_PLUS_C)
+int enablePin = 4;
+int rxPin = 16;
+int txPin = 17;
+#elif defined(ARDUINO_ESP32S2_THING_PLUS)
+int enablePin = 3;
+int rxPin = 33;
+int txPin = 34;
+#endif
 
 //DMX value array and size. Entry 0 will hold startbyte
 uint8_t dmxData[dmxMaxChannel] = {};
@@ -124,7 +141,11 @@ void SparkFunDMX::update() {
     delayMicroseconds(88);  
     digitalWrite(txPin, HIGH); //4 Us Mark After Break
     delayMicroseconds(1);
+    #ifdef U2TXD_OUT_IDX // Some ESP32 boards only have 2 UARTs
     pinMatrixOutAttach(txPin, U2TXD_OUT_IDX, false, false);
+    #else
+    pinMatrixOutAttach(txPin, U1TXD_OUT_IDX, false, false);
+    #endif
 
     DMXSerial.write(dmxData, chanSize);
     DMXSerial.flush();

--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -72,7 +72,7 @@ void IRAM_ATTR onTimer() {
 	{
 		_interruptCounter++;
 	}
-	if (_interruptCounter > 9)
+	if ((_interruptCounter > 9) && (_startCodeDetected == false))
 	{	
 		portENTER_CRITICAL_ISR(&timerMux);
 		_startCodeDetected = true;
@@ -84,7 +84,7 @@ void IRAM_ATTR onTimer() {
 
 void SparkFunDMX::initRead(int chanQuant) {
 	
-  timer = timerBegin(0, 1, true);
+  timer = timerBegin(0, 2, true);
   timerAttachInterrupt(timer, &onTimer, true);
   timerAlarmWrite(timer, 320, true);
   timerAlarmEnable(timer);

--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -94,7 +94,6 @@ void SparkFunDMX::initRead(int chanQuant) {
     chanQuant = defaultMax;
   }
   chanSize = chanQuant;
-  pinMode(13, OUTPUT);
   pinMode(enablePin, OUTPUT);
   digitalWrite(enablePin, LOW);
   pinMode(rxPin, INPUT);

--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -51,7 +51,11 @@ uint8_t dmxData[dmxMaxChannel] = {};
 int chanSize;
 int currentChannel = 0;
 
+#if defined(ARDUINO_ESP32_THING_PLUS) || defined(ARDUINO_ESP32_THING_PLUS_C)
 HardwareSerial DMXSerial(2);
+#elif defined(ARDUINO_ESP32S2_THING_PLUS)
+HardwareSerial DMXSerial(1);
+#endif
 
 /* Interrupt Timer for DMX Receive */
 hw_timer_t * timer = NULL;


### PR DESCRIPTION
Bump version number to v1.1.0
Fix compilation on ESP32-S2, as discussed in #10
Change architectures to esp32 in library.properties Add compiler error if ESP32 Thing Plus board is not selected Redefine pins for different Thing Plus Boards