### PR TITLE
V2 overhaul

### DIFF
--- a/examples/Example1-DMXOutput/Example1-DMXOutput.ino
+++ b/examples/Example1-DMXOutput/Example1-DMXOutput.ino
@@ -1,62 +1,75 @@
 /*
-  Read the 5 Channels of DMX Data coming from an ESP32 shield running Example 1
-  By: Andy England
+  Writes DMX data to channel 1
+
+  By: Dryw Wade
   SparkFun Electronics
-  Date: , 2018
+  Date: 10/3/2023
   License: GNU. See license file for more information but you can
   basically do whatever you want with this code.
   This example runs two servos and a number of LED's off of 5 DMX channels
   
   Feel like supporting open source hardware?
   Buy a board from SparkFun! https://www.sparkfun.com/products/15110
+  
   Hardware Connections:
-  Connect pan/tilt servos to pins DATA1 and DATA2, connect LEDs to CLOCK and DATA0. Connect a DMX XLR-3 Cable in between the Output and Input shields
+  Connect a Thing Plus board to the SparkFun DMX Shield, and connect a DMX XLR-3
+  cable between the shield and another device that outputs DMX data. You can use
+  a second board and shield running Example 2!
 */
 
+// Inlcude DMX library
 #include <SparkFunDMX.h>
 
+// Create DMX object
 SparkFunDMX dmx;
 
-//Channel Definitions
-#define TOTAL_CHANNELS 5
+// Create serial port to be used for DMX interface. Exact implementation depends
+// on platform, this example is for the ESP32
+HardwareSerial dmxSerial(2);
 
-#define HUE_CHANNEL 1
-#define SATURATION_CHANNEL 2
-#define VALUE_CHANNEL 3
-#define PAN_CHANNEL 4
-#define TILT_CHANNEL 5
+// Pin definitions, required by DMX library
+// These are for the SparkFun ESP32 Thing Plus (Micro-B)
+uint8_t rxPin = 16;
+uint8_t txPin = 17;
+uint8_t enPin = 21;
 
-//Pin Definitions for ESP32 WROOM DMX to LED Shield
-#define CLOCK = 5;
-#define DATA0 = 19;
-#define DATA1 = 18;
-#define DATA2 = 27;
+// Number of DMX channels, can be up tp 512
+uint16_t numChannels = 1;
 
-uint8_t x = 0;
+// Create a counter for demonstration
+uint8_t counter = 0;
 
-void setup() {
-  Serial.begin(115200);
-  delay(3000);
-  Serial.println("starting...");
-  dmx.initWrite(TOTAL_CHANNELS);           // initialization for complete bus
-  Serial.println("initialized...");
-  delay(200);               // wait a while (not necessary)
+void setup()
+{
+    Serial.begin(115200);
+    Serial.println("SparkFun DMX Example 1 - Output");
+
+    // Set pins for DMX serial port (may depend on platform)
+    dmxSerial.setPins(rxPin, txPin);
+
+    // Begin DMX
+    dmx.begin(dmxSerial, rxPin, txPin, enPin, numChannels);
+
+    // Set communicaiton direction, which can be changed on the fly as needed
+    dmx.setComDir(DMX_WRITE_DIR);
+
+    Serial.println("DMX initialized!");
 }
 
-void loop() {
-  for (int channel = 1; channel <= TOTAL_CHANNELS; channel++) //We don't (and can't) write to channel 0 as it contains 0x00, the DMX start code
-  {
-    if (channel == SATURATION_CHANNEL || channel == VALUE_CHANNEL) //Write the same value (190/255) = 74.5% to both saturation and value.
-    {
-      dmx.write(channel, 190);
-    }
-    else if (channel == HUE_CHANNEL || channel == PAN_CHANNEL || channel == TILT_CHANNEL) //Sweep across our servos as well as a rainbow cycle.
-    {
-      dmx.write(channel, x);
-    }
-  }
-  Serial.print(x++);//Print and increment x. Since x is an unsigned 8 bit integer it will loop back to 0 if we try to increment it past 255
-  dmx.update(); // update the DMX bus witht he values that we have written
-  Serial.println(": updated!");
-  delay(100);
+void loop()
+{
+    // Write counter to channel 1
+    dmx.writeByte(counter, 1);
+
+    // Once all data has been written, update() must be called to actually send it
+    dmx.update();
+
+    Serial.print("DMX: sent value to channel 1: ");
+    Serial.println(counter);
+
+    // Increment counter (overflows back to 0 after 255)
+    counter++;
+
+    // Slow down communication for this example
+    delay(100);
 }

--- a/examples/Example1-DMXOutput/Example1-DMXOutput.ino
+++ b/examples/Example1-DMXOutput/Example1-DMXOutput.ino
@@ -27,16 +27,13 @@ SparkFunDMX dmx;
 // on platform, this example is for the ESP32
 HardwareSerial dmxSerial(2);
 
-// Pin definitions, required by DMX library
-// These are for the SparkFun ESP32 Thing Plus (Micro-B)
-uint8_t rxPin = 16;
-uint8_t txPin = 17;
+// Enable pin for DMX shield (Free pin on Thing Plus or Feather pinout)
 uint8_t enPin = 21;
 
 // Number of DMX channels, can be up tp 512
 uint16_t numChannels = 1;
 
-// Create a counter for demonstration
+// Create a counter as example data
 uint8_t counter = 0;
 
 void setup()
@@ -44,11 +41,11 @@ void setup()
     Serial.begin(115200);
     Serial.println("SparkFun DMX Example 1 - Output");
 
-    // Set pins for DMX serial port (may depend on platform)
-    dmxSerial.setPins(rxPin, txPin);
+    // Begin DMX serial port
+    dmxSerial.begin(DMX_BAUD, DMX_FORMAT);
 
-    // Begin DMX
-    dmx.begin(dmxSerial, rxPin, txPin, enPin, numChannels);
+    // Begin DMX driver
+    dmx.begin(dmxSerial, enPin, numChannels);
 
     // Set communicaiton direction, which can be changed on the fly as needed
     dmx.setComDir(DMX_WRITE_DIR);

--- a/examples/Example2-DMXInput/Example2-DMXInput.ino
+++ b/examples/Example2-DMXInput/Example2-DMXInput.ino
@@ -27,28 +27,22 @@ SparkFunDMX dmx;
 // on platform, this example is for the ESP32
 HardwareSerial dmxSerial(2);
 
-// Pin definitions, required by DMX library
-// These are for the SparkFun ESP32 Thing Plus (Micro-B)
-uint8_t rxPin = 16;
-uint8_t txPin = 17;
+// Enable pin for DMX shield (Free pin on Thing Plus or Feather pinout)
 uint8_t enPin = 21;
 
 // Number of DMX channels, can be up tp 512
 uint16_t numChannels = 1;
-
-// Create a counter for demonstration
-uint8_t counter = 0;
 
 void setup()
 {
     Serial.begin(115200);
     Serial.println("SparkFun DMX Example 2 - Input");
 
-    // Set pins for DMX serial port (may depend on platform)
-    dmxSerial.setPins(rxPin, txPin);
+    // Begin DMX serial port
+    dmxSerial.begin(DMX_BAUD, DMX_FORMAT);
 
-    // Begin DMX
-    dmx.begin(dmxSerial, rxPin, txPin, enPin, numChannels);
+    // Begin DMX driver
+    dmx.begin(dmxSerial, enPin, numChannels);
 
     // Set communicaiton direction, which can be changed on the fly as needed
     dmx.setComDir(DMX_READ_DIR);
@@ -61,7 +55,7 @@ void loop()
     // Wait until data has been received
     while(dmx.dataAvailable() == false)
     {
-        // Update must be called to update received data
+        // Must called update() to actually check for received data
         dmx.update();
     }
 

--- a/examples/Example3-MovingHead/Example3-MovingHead.ino
+++ b/examples/Example3-MovingHead/Example3-MovingHead.ino
@@ -25,7 +25,7 @@ char password[] = "artnetnode";
 
 // Artnet settings
 ArtnetWifi artnet;
-WiFiUdp UdpSend;
+WiFiUDP UdpSend;
 const int startUniverse = 0;
 const int endUniverse = 0;//end Universe should be total channels/512
 
@@ -89,6 +89,8 @@ void onDmxFrame(uint16_t universe, uint16_t length, uint8_t sequence, uint8_t* d
 void setup()
 {
   Serial.begin(115200);
+  Serial.println("SparkFun DMX Example 3 - Moving Head");
+
   //Fixture Hardware Declarations
   FastLED.addLeds<APA102, DATA0, CLOCK, BGR>(matrix, NUM_LEDS);
   pan.attach(DATA1);

--- a/keywords.txt
+++ b/keywords.txt
@@ -12,13 +12,22 @@ SparkFunDMX		KEYWORD1
 # Methods and Functions (KEYWORD2)
 #######################################
 
-initRead		KEYWORD2
-initWrite 		KEYWORD2
-read			KEYWORD2
-write			KEYWORD2
-update 			KEYWORD2
-
+begin           KEYWORD2
+setComDir       KEYWORD2
+writeBytes      KEYWORD2
+writeByte       KEYWORD2
+readBytes       KEYWORD2
+readByte        KEYWORD2
+dataAvailable   KEYWORD2
+update          KEYWORD2
 
 #######################################
 # Constants (LITERAL1)
 #######################################
+
+DMX_MAX_CHANNELS            LITERAL1
+DMX_BREAK_DURATION_MICROS   LITERAL1
+DMX_BAUD                    LITERAL1
+DMX_FORMAT                  LITERAL1
+DMX_WRITE_DIR               LITERAL1
+DMX_READ_DIR                LITERAL1

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=SparkFun DMX Shield Library
-version=1.0.5
+version=2.0.0
 author=SparkFun Electronics <techsupport@sparkfun.com>
 maintainer=SparkFun Electronics <sparkfun.com>
 sentence=Library for the SparkFun ESP32 DMX to LED Shield

--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -1,11 +1,11 @@
 /******************************************************************************
 SparkFunDMX.h
 Arduino Library for the SparkFun ESP32 LED to DMX Shield
-Andy England @ SparkFun Electronics
-7/22/2019
+Dryw Wade @ SparkFun Electronics
+10/3/2023
 
 Development environment specifics:
-Arduino IDE 1.6.4
+Arduino IDE 2.2.1
 
 This code is released under the [MIT License](http://opensource.org/licenses/MIT).
 Please review the LICENSE.md file included with this example. If you have any questions 
@@ -14,142 +14,169 @@ Distributed as-is; no warranty is given.
 ******************************************************************************/
 
 /* ----- LIBRARIES ----- */
-#include <Arduino.h>
-
 #include "SparkFunDMX.h"
-#include <HardwareSerial.h>
 
-#define dmxMaxChannel  513
-#define defaultMax 32
+// Static member definitions
+uint8_t SparkFunDMX::_rxPin;
+uint8_t SparkFunDMX::_txPin;
+uint8_t SparkFunDMX::_enPin;
+uint16_t SparkFunDMX::_numChannels;
+uint8_t SparkFunDMX::_dmxBuffer[DMX_MAX_CHANNELS];
+HardwareSerial*SparkFunDMX:: _dmxSerial;
+bool SparkFunDMX::_comDir = DMX_READ_DIR;
+bool SparkFunDMX::_dataAvailable = false;
+bool SparkFunDMX::_synced = false;
+uint32_t SparkFunDMX::_tStartBreak = 0;
 
-#define DMXSPEED       250000
-#define DMXFORMAT      SERIAL_8N2
-
-int enablePin = 21;		//dafault on ESP32
-int rxPin = 16;
-int txPin = 17;
-
-//DMX value array and size. Entry 0 will hold startbyte
-uint8_t dmxData[dmxMaxChannel] = {};
-int chanSize;
-int currentChannel = 0;
-
-HardwareSerial DMXSerial(2);
-
-/* Interrupt Timer for DMX Receive */
-hw_timer_t * timer = NULL;
-portMUX_TYPE timerMux = portMUX_INITIALIZER_UNLOCKED;
-
-volatile int _interruptCounter;
-volatile bool _startCodeDetected = false;
-
-volatile bool ledPin = false;
-
-/* Start Code is detected by 21 low interrupts */
-void IRAM_ATTR onTimer() {
-	if (digitalRead(rxPin) == 1)
-	{
-		_interruptCounter = 0; //If the RX Pin is high, we are not in an interrupt
-	}
-	else
-	{
-		_interruptCounter++;
-	}
-	if (_interruptCounter > 9)
-	{	
-		portENTER_CRITICAL_ISR(&timerMux);
-		_startCodeDetected = true;
-		DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);
-		portEXIT_CRITICAL_ISR(&timerMux);
-		_interruptCounter = 0;
-	}
+void SparkFunDMX::_rxISR()
+{
+    // If communication direction is writing, skip
+    if(_comDir == DMX_WRITE_DIR)
+        return;
+    
+    // If already synced, skip
+    if(_synced == true)
+        return;
+    
+    // Check if pin went low or high
+    if(digitalRead(_rxPin) == LOW)
+    {
+        // Pin just went low, start timer
+        _tStartBreak = micros();
+    }
+    else
+    {
+        // Pin just went high, check if low pulse was long enough to be the
+        // syncronization break signal
+        if((micros() - _tStartBreak) >= (DMX_BREAK_DURATION_MICROS - DMX_BREAK_DURATION_MARGIN))
+        {
+            // This must have been the sync signal, update flag and flush serial
+            _synced = true;
+            _dmxSerial->flush(false);
+        }
+    }
 }
 
-void SparkFunDMX::initRead(int chanQuant) {
-	
-  timer = timerBegin(0, 1, true);
-  timerAttachInterrupt(timer, &onTimer, true);
-  timerAlarmWrite(timer, 320, true);
-  timerAlarmEnable(timer);
-  _READWRITE = _READ;
-  if (chanQuant > dmxMaxChannel || chanQuant <= 0) 
-  {
-    chanQuant = defaultMax;
-  }
-  chanSize = chanQuant;
-  pinMode(13, OUTPUT);
-  pinMode(enablePin, OUTPUT);
-  digitalWrite(enablePin, LOW);
-  pinMode(rxPin, INPUT);
+void SparkFunDMX::begin(HardwareSerial& port, uint8_t rxPin, uint8_t txPin, uint8_t enPin, uint16_t numChannels)
+{
+    // Store serial stream port
+    _dmxSerial = &port;
+
+    // Store pin assignments
+    _rxPin = rxPin;
+    _txPin = txPin;
+    _enPin = enPin;
+
+    // Store number of requested channels, ensuring it's not above the limit
+    _numChannels = numChannels+1;
+    if(_numChannels > DMX_MAX_CHANNELS)
+        _numChannels = DMX_MAX_CHANNELS;
+
+    // Begin serial
+    _dmxSerial->begin(DMX_BAUD, DMX_FORMAT);
+
+    // Attach interrupt to RX pin for synchronization
+    attachInterrupt(digitalPinToInterrupt(_rxPin), _rxISR, CHANGE);
+
+    // Configure enable pin
+    pinMode(_enPin, OUTPUT);
+    setComDir(DMX_READ_DIR);
 }
 
-// Set up the DMX-Protocol
-void SparkFunDMX::initWrite (int chanQuant) {
+void SparkFunDMX::setComDir(bool comDir)
+{
+    // Store communication direction
+    _comDir = comDir;
+    
+    // Flush serial buffer contents
+    _dmxSerial->flush(false);
 
-  _READWRITE = _WRITE;
-  if (chanQuant > dmxMaxChannel || chanQuant <= 0) {
-    chanQuant = defaultMax;
-  }
-
-  chanSize = chanQuant + 1; //Add 1 for start code
-
-  DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);
-  pinMode(enablePin, OUTPUT);
-  digitalWrite(enablePin, HIGH);
+    if(comDir == DMX_WRITE_DIR)
+    {
+        digitalWrite(_enPin, HIGH);
+    }
+    else // DMX_READ_DIR
+    {
+        digitalWrite(_enPin, LOW);
+    }
 }
 
-// Function to read DMX data
-uint8_t SparkFunDMX::read(int Channel) {
-  if (Channel > chanSize) Channel = chanSize;
-  return(dmxData[Channel - 1]); //subtract one to account for start byte
+void SparkFunDMX::writeBytes(uint8_t* data, uint16_t numBytes, uint16_t startChannel)
+{
+    // Copy data into buffer
+    uint8_t* startPtr = _dmxBuffer + startChannel;
+    memcpy(startPtr, data, numBytes);
 }
 
-// Function to send DMX data
-void SparkFunDMX::write(int Channel, uint8_t value) {
-  if (Channel < 0) Channel = 0;
-  if (Channel > chanSize) chanSize = Channel;
-  dmxData[0] = 0;
-  dmxData[Channel] = value; //add one to account for start byte
+void SparkFunDMX::writeByte(uint8_t data, uint16_t channel)
+{
+    _dmxBuffer[channel] = data;
 }
 
+void SparkFunDMX::readBytes(uint8_t* data, uint16_t numBytes, uint16_t startChannel)
+{
+    // Copy data into buffer
+    uint8_t* startPtr = _dmxBuffer + startChannel;
+    memcpy(data, startPtr, numBytes);
 
-
-void SparkFunDMX::update() {
-  if (_READWRITE == _WRITE)
-  {
-	DMXSerial.begin(DMXSPEED, DMXFORMAT, rxPin, txPin);//Begin the Serial port
-    pinMatrixOutDetach(txPin, false, false); //Detach our
-    pinMode(txPin, OUTPUT); 
-    digitalWrite(txPin, LOW); //88 uS break
-    delayMicroseconds(88);  
-    digitalWrite(txPin, HIGH); //4 Us Mark After Break
-    delayMicroseconds(1);
-    pinMatrixOutAttach(txPin, U2TXD_OUT_IDX, false, false);
-
-    DMXSerial.write(dmxData, chanSize);
-    DMXSerial.flush();
-    DMXSerial.end();//clear our DMX array, end the Hardware Serial port
-  }
-  else if (_READWRITE == _READ)//In a perfect world, this function ends serial communication upon packet completion and attaches RX to a CHANGE interrupt so the start code can be read again
-  { 
-	if (_startCodeDetected == true)
-	{
-		while (DMXSerial.available())
-		{
-			dmxData[currentChannel++] = DMXSerial.read();
-		}
-	if (currentChannel > chanSize) //Set the channel counter back to 0 if we reach the known end size of our packet
-	{
-		
-      portENTER_CRITICAL(&timerMux);
-	  _startCodeDetected = false;
-	  DMXSerial.flush();
-	  DMXSerial.end();
-      portEXIT_CRITICAL(&timerMux);
-	  currentChannel = 0;
-	}
-	}
-  }
+    _dataAvailable = false;
 }
 
-// Function to update the DMX bus
+uint8_t SparkFunDMX::readByte(uint16_t channel)
+{
+    _dataAvailable = false;
+    return _dmxBuffer[channel];
+}
+
+bool SparkFunDMX::dataAvailable()
+{
+    return _dataAvailable;
+}
+
+bool SparkFunDMX::update()
+{
+    if(_comDir == DMX_WRITE_DIR)
+    {
+        // We need to send a break signal to indicate the start of the message.
+        // Arduino doesn't really have a way to actually send a break signal, so
+        // this is a hacky solution. The baud rate is reduced such that sending
+        // a zero byte creates a sufficiently long pulse to simulate a break
+        
+        // Reduce baud rate
+        uint32_t breakBaud = 1000000 * 8 / DMX_BREAK_DURATION_MICROS;
+        _dmxSerial->updateBaudRate(breakBaud);
+
+        // Send a zero at this new baud rate
+        _dmxSerial->write(0);
+        _dmxSerial->flush();
+
+        // Return baud rate to original value
+        _dmxSerial->updateBaudRate(DMX_BAUD);
+
+        // Send message
+        _dmxSerial->write(_dmxBuffer, _numChannels);
+
+        // Success
+        return true;
+    }
+    else // DMX_READ_DIR
+    {
+        // Check if the break signal has been synced, and we've received the
+        // amount of data expected
+        if(_synced && (_dmxSerial->available() >= _numChannels))
+        {
+            // Read bytes into buffer
+            _dmxSerial->read(_dmxBuffer, _numChannels);
+            
+            // Reset flags
+            _dataAvailable = true;
+            _synced = false;
+            
+            // Success
+            return true;
+        }
+    }
+
+    // Something went wrong (most likely haven't received all the bytes yet)
+    return false;
+}

--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -16,75 +16,40 @@ Distributed as-is; no warranty is given.
 /* ----- LIBRARIES ----- */
 #include "SparkFunDMX.h"
 
-// Static member definitions
-uint8_t SparkFunDMX::_rxPin;
-uint8_t SparkFunDMX::_txPin;
-uint8_t SparkFunDMX::_enPin;
-uint16_t SparkFunDMX::_numChannels;
+// Static member definitions and initial values
+HardwareSerial* SparkFunDMX::_dmxSerial = nullptr;
 uint8_t SparkFunDMX::_dmxBuffer[DMX_MAX_CHANNELS];
-HardwareSerial*SparkFunDMX:: _dmxSerial;
+uint16_t SparkFunDMX::_numChannels = 1;
+uint8_t SparkFunDMX::_enPin = 255;
 bool SparkFunDMX::_comDir = DMX_READ_DIR;
 bool SparkFunDMX::_dataAvailable = false;
-bool SparkFunDMX::_synced = false;
-uint32_t SparkFunDMX::_tStartBreak = 0;
 
-void SparkFunDMX::_rxISR()
-{
-    // If communication direction is writing, skip
-    if(_comDir == DMX_WRITE_DIR)
-        return;
-    
-    // If already synced, skip
-    if(_synced == true)
-        return;
-    
-    // Check if pin went low or high
-    if(digitalRead(_rxPin) == LOW)
-    {
-        // Pin just went low, start timer
-        _tStartBreak = micros();
-    }
-    else
-    {
-        // Pin just went high, check if low pulse was long enough to be the
-        // syncronization break signal
-        if((micros() - _tStartBreak) >= (DMX_BREAK_DURATION_MICROS - DMX_BREAK_DURATION_MARGIN))
-        {
-            // This must have been the sync signal, update flag and flush serial
-            _synced = true;
-            _dmxSerial->flush(false);
-        }
-    }
-}
-
-void SparkFunDMX::begin(HardwareSerial& port, uint8_t rxPin, uint8_t txPin, uint8_t enPin, uint16_t numChannels)
+void SparkFunDMX::begin(HardwareSerial& port, uint8_t enPin, uint16_t numChannels)
 {
     // Store serial stream port
     _dmxSerial = &port;
 
-    // Store pin assignments
-    _rxPin = rxPin;
-    _txPin = txPin;
+    // Store enable pin
     _enPin = enPin;
 
-    // Store number of requested channels, ensuring it's not above the limit
-    _numChannels = numChannels+1;
+    // Store number of requested channels, plus 1 for channel 0
+    _numChannels = numChannels + 1;
+
+    // Ensure number of channels is not above the limit
     if(_numChannels > DMX_MAX_CHANNELS)
         _numChannels = DMX_MAX_CHANNELS;
 
-    // Begin serial
-    _dmxSerial->begin(DMX_BAUD, DMX_FORMAT);
-
-    // Attach interrupt to RX pin for synchronization
-    attachInterrupt(digitalPinToInterrupt(_rxPin), _rxISR, CHANGE);
-
-    // Configure enable pin
+    // Configure enable pin, default to reading
     pinMode(_enPin, OUTPUT);
     setComDir(DMX_READ_DIR);
 }
 
 void SparkFunDMX::setComDir(bool comDir)
 {
+    // No need to do anything if this direction is already set
+    if(_comDir == comDir)
+        return;
+
     // Store communication direction
     _comDir = comDir;
     
@@ -93,10 +58,12 @@ void SparkFunDMX::setComDir(bool comDir)
 
     if(comDir == DMX_WRITE_DIR)
     {
+        // Enable output
         digitalWrite(_enPin, HIGH);
     }
     else // DMX_READ_DIR
     {
+        // Disable output
         digitalWrite(_enPin, LOW);
     }
 }
@@ -110,21 +77,26 @@ void SparkFunDMX::writeBytes(uint8_t* data, uint16_t numBytes, uint16_t startCha
 
 void SparkFunDMX::writeByte(uint8_t data, uint16_t channel)
 {
+    // Store data
     _dmxBuffer[channel] = data;
 }
 
 void SparkFunDMX::readBytes(uint8_t* data, uint16_t numBytes, uint16_t startChannel)
 {
+    // Clear flag, this is now old data
+    _dataAvailable = false;
+
     // Copy data into buffer
     uint8_t* startPtr = _dmxBuffer + startChannel;
     memcpy(data, startPtr, numBytes);
-
-    _dataAvailable = false;
 }
 
 uint8_t SparkFunDMX::readByte(uint16_t channel)
 {
+    // Clear flag, this is now old data
     _dataAvailable = false;
+
+    // Return requested data
     return _dmxBuffer[channel];
 }
 
@@ -139,7 +111,7 @@ bool SparkFunDMX::update()
     {
         // We need to send a break signal to indicate the start of the message.
         // Arduino doesn't really have a way to actually send a break signal, so
-        // this is a hacky solution. The baud rate is reduced such that sending
+        // this is a hacky solution: the baud rate is reduced such that sending
         // a zero byte creates a sufficiently long pulse to simulate a break
         
         // Reduce baud rate
@@ -159,22 +131,36 @@ bool SparkFunDMX::update()
         // Success
         return true;
     }
-    else // DMX_READ_DIR
+    // else _comDir == DMX_READ_DIR
+    // Check if we've received the amount of data expected, +1 for break signal
+    else if(_dmxSerial->available() >= (_numChannels + 1))
     {
-        // Check if the break signal has been synced, and we've received the
-        // amount of data expected
-        if(_synced && (_dmxSerial->available() >= _numChannels))
+        // We need to detect a break signal indicating the start of the message.
+        // Arduino doesn't really have a way to actually read a break signal, it
+        // will instead appear as an extra zero byte at the start. This has the
+        // risk of not synchronizing properly, but it should be resolved by
+        // calling update() freuently enough (ie. faster than messages are sent)
+        // and flushing the RX buffer if not synced. We can do one other check:
+        // after the break signal, channel 0 is sent, which should always have a
+        // value of zero
+
+        // Read out break signal (hopefully!) and peek at channel 0 (hopefully!)
+        if((_dmxSerial->read() != 0) || (_dmxSerial->peek() != 0))
         {
-            // Read bytes into buffer
-            _dmxSerial->read(_dmxBuffer, _numChannels);
-            
-            // Reset flags
-            _dataAvailable = true;
-            _synced = false;
-            
-            // Success
-            return true;
+            // If we get here, then we're not synced properly. We can try to
+            // flush out all the data and hope the next time is synced
+            _dmxSerial->flush(false);
+            return false;
         }
+        
+        // We're probably synced! Read data into buffer
+        _dmxSerial->read(_dmxBuffer, _numChannels);
+
+        // Set flag indicating we have new data
+        _dataAvailable = true;
+        
+        // Success
+        return true;
     }
 
     // Something went wrong (most likely haven't received all the bytes yet)

--- a/src/SparkFunDMX.h
+++ b/src/SparkFunDMX.h
@@ -22,16 +22,14 @@ Distributed as-is; no warranty is given.
 // DMX supports up to 512 channels, plus 1 for channel 0
 #define DMX_MAX_CHANNELS 513
 
-// DMX messages are started with a break signal of 88us. Also define a small
-// margin for signals slightly shorter than 88us
+// DMX messages are started with a break signal of at least 88us
 #define DMX_BREAK_DURATION_MICROS 88
-#define DMX_BREAK_DURATION_MARGIN 8
 
 // DMX operates at 250kbps with 2 parity bits
 #define DMX_BAUD 250000
 #define DMX_FORMAT SERIAL_8N2
 
-// DMX can't send and transmit at same time
+// Macros for read or write direcion, DMX can't send and transmit at same time
 #define DMX_WRITE_DIR 0
 #define DMX_READ_DIR 1
 
@@ -39,12 +37,11 @@ class SparkFunDMX
 {
     public:
         /// @brief Begins DMX class
-        /// @param port Serial port for communication
-        /// @param rxPin Receive pin used by serial port
-        /// @param txPin Transmit pin used by serial port
+        /// @param port Serial port for communication. This library will not
+        /// begin the serial port, that must be done before calling dmx.begin()
         /// @param enPin Enable pin connected to bridge chip, used for direction
         /// @param numChannels Number of DMX channels, 512 max
-        static void begin(HardwareSerial& port, uint8_t rxPin, uint8_t txPin, uint8_t enPin, uint16_t numChannels);
+        static void begin(HardwareSerial& port, uint8_t enPin, uint16_t numChannels);
         
         /// @brief Set communication direction, either read or write
         /// @param comDir Either DMX_WRITE_DIR or DMX_READ_DIR
@@ -82,20 +79,13 @@ class SparkFunDMX
         static bool update();
 
     private:
-        
-        /// @brief Interrupt service routine to detect break signal
-        static void _rxISR();
-        
-        static uint8_t _rxPin;
-        static uint8_t _txPin;
-        static uint8_t _enPin;
-        static uint16_t _numChannels;
-        static uint8_t _dmxBuffer[DMX_MAX_CHANNELS];
+        // Member variables
         static HardwareSerial* _dmxSerial;
+        static uint8_t _dmxBuffer[DMX_MAX_CHANNELS];
+        static uint16_t _numChannels;
+        static uint8_t _enPin;
         static bool _comDir;
         static bool _dataAvailable;
-        static bool _synced;
-        static uint32_t _tStartBreak;
 };
 
 #endif


### PR DESCRIPTION
Rewrite of entire library:

- Should work with any platform (only tested with SparkFun ESP32 Thing Plus boards so far)
- ~Now uses interrupts instead of timer for break signal detection~
    - Break signals are detected by looking at received data. The break signal should be read as a zero, followed by a zero for channel 0. If that's not detected, the buffer is flushed to hopefully sync on the next iteration. It's not necessarily guaranteed to work perfectly, but it seems to work well in testing, and it provides a solution that should work on any platform (interrupts don't always trigger properly on pins used for UART)
- DMX serial port is no longer restarted over and over
- Serial port must be started before calling `begin()` of this library, which should help with platform compatibility
- First examples are simplified