### PR TITLE
Allow for more than one instance

### DIFF
--- a/src/SparkFunDMX.cpp
+++ b/src/SparkFunDMX.cpp
@@ -16,14 +16,6 @@ Distributed as-is; no warranty is given.
 /* ----- LIBRARIES ----- */
 #include "SparkFunDMX.h"
 
-// Static member definitions and initial values
-HardwareSerial* SparkFunDMX::_dmxSerial = nullptr;
-uint8_t SparkFunDMX::_dmxBuffer[DMX_MAX_CHANNELS];
-uint16_t SparkFunDMX::_numChannels = 1;
-uint8_t SparkFunDMX::_enPin = 255;
-bool SparkFunDMX::_comDir = DMX_READ_DIR;
-bool SparkFunDMX::_dataAvailable = false;
-
 void SparkFunDMX::begin(HardwareSerial& port, uint8_t enPin, uint16_t numChannels)
 {
     // Store serial stream port
@@ -39,9 +31,15 @@ void SparkFunDMX::begin(HardwareSerial& port, uint8_t enPin, uint16_t numChannel
     if(_numChannels > DMX_MAX_CHANNELS)
         _numChannels = DMX_MAX_CHANNELS;
 
+    memset(_dmxBuffer, 0, _numChannels);
+
     // Configure enable pin, default to reading
     pinMode(_enPin, OUTPUT);
+
+    _comDir = DMX_WRITE_DIR;
     setComDir(DMX_READ_DIR);
+
+    _dataAvailable = false;
 }
 
 void SparkFunDMX::setComDir(bool comDir)

--- a/src/SparkFunDMX.h
+++ b/src/SparkFunDMX.h
@@ -41,51 +41,51 @@ class SparkFunDMX
         /// begin the serial port, that must be done before calling dmx.begin()
         /// @param enPin Enable pin connected to bridge chip, used for direction
         /// @param numChannels Number of DMX channels, 512 max
-        static void begin(HardwareSerial& port, uint8_t enPin, uint16_t numChannels);
+        void begin(HardwareSerial& port, uint8_t enPin, uint16_t numChannels);
         
         /// @brief Set communication direction, either read or write
         /// @param comDir Either DMX_WRITE_DIR or DMX_READ_DIR
-        static void setComDir(bool comDir);
+        void setComDir(bool comDir);
         
         /// @brief Copy data from a provided byte buffer
         /// @param data Buffer with data to be sent
         /// @param numBytes Number of bytes to copy from buffer
         /// @param startChannel Channel to start copying data to
-        static void writeBytes(uint8_t* data, uint16_t numBytes, uint16_t startChannel = 1);
+        void writeBytes(uint8_t* data, uint16_t numBytes, uint16_t startChannel = 1);
         
         /// @brief Copy a single byte to a specified channel
         /// @param data Byte to copy
         /// @param channel Channel to copy data to
-        static void writeByte(uint8_t data, uint16_t channel);
+        void writeByte(uint8_t data, uint16_t channel);
         
         /// @brief Copy data to a provided byte buffer
         /// @param data Buffer with data to be read
         /// @param numBytes Number of bytes to copy to buffer
         /// @param startChannel Channel to start copying data from
-        static void readBytes(uint8_t* data, uint16_t numBytes, uint16_t startChannel = 1);
+        void readBytes(uint8_t* data, uint16_t numBytes, uint16_t startChannel = 1);
         
         /// @brief Copy a single byte from a specified channel
         /// @param channel Channel to copy data from
         /// @return Byte from specified channel
-        static uint8_t readByte(uint16_t channel);
+        uint8_t readByte(uint16_t channel);
         
         /// @brief When reading, returns whether data has been received
         /// @return True if data is available, else false
-        static bool dataAvailable();
+        bool dataAvailable();
         
         /// @brief When in read mode, will check to see if new data is available
         /// and ready to be read. When in write mode, will actually send out data
         /// @return True if successful, else false
-        static bool update();
+        bool update();
 
     private:
         // Member variables
-        static HardwareSerial* _dmxSerial;
-        static uint8_t _dmxBuffer[DMX_MAX_CHANNELS];
-        static uint16_t _numChannels;
-        static uint8_t _enPin;
-        static bool _comDir;
-        static bool _dataAvailable;
+        HardwareSerial* _dmxSerial;
+        uint8_t _dmxBuffer[DMX_MAX_CHANNELS];
+        uint16_t _numChannels;
+        uint8_t _enPin;
+        bool _comDir;
+        bool _dataAvailable;
 };
 
 #endif


### PR DESCRIPTION
Remove the static keyword from the header.

This allows for more instances when you have several HardwareSerial's.

For reference:
https://forum.arduino.cc/t/could-this-library-be-edited-to-run-more-than-one-instance/1191897/38